### PR TITLE
Change MessageError to RequestError and use string for code property

### DIFF
--- a/doc/sdk/basic-service-sample.md
+++ b/doc/sdk/basic-service-sample.md
@@ -98,8 +98,17 @@ client.asyncRequest(request,
     // Display the contents of an error, if one occurred
     if (error) {
       console.log('Request error: ' + error.message)
-      if (error instanceof dxl.MessageError) {
+      // The 'code' property, if set, typically has a string
+      // representation of the error code.
+      if (error.code) {
         console.log('Request error code: ' + error.code)
+      // If no string representation is available for the error code
+      // but the error is a DXL 'RequestError', a numeric error
+      // code should be available in the
+      // 'dxlErrorResponse.errorCode' property.
+      } else if (error.dxlErrorResponse) {
+        console.log('Request error code: ' +
+          error.dxlErrorResponse.errorCode)
       }
     // No error occurred, so extract information from the response. The
     // toString() call converts the payload from a binary Buffer into a

--- a/index.js
+++ b/index.js
@@ -8,7 +8,11 @@ exports.ErrorResponse = require('./lib/error-response')
 exports.Event = require('./lib/event')
 exports.MalformedBrokerError = require('./lib/malformed-broker-error')
 exports.Message = require('./lib/message')
-exports.MessageError = require('./lib/message-error')
 exports.Request = require('./lib/request')
+exports.RequestError = require('./lib/request-error')
 exports.Response = require('./lib/response')
+exports.ResponseErrorCode = require('./lib/response-error-code')
 exports.ServiceRegistrationInfo = require('./lib/service-registration-info')
+
+// Leaving this for backward compatibility for now
+exports.MessageError = exports.RequestError

--- a/lib/client.js
+++ b/lib/client.js
@@ -550,12 +550,21 @@ Object.defineProperty(Client.prototype, 'subscriptions', {
 /**
  * Sends a {@link Request} message to a remote DXL service asynchronously. An
  * optional response callback can be specified. This callback will be invoked
- * when the corresponding {@link Response} message is received by the client.
+ * when the corresponding {@link Response} message (or an error) is received by
+ * the client.
  * @param {Request} request - The request message to send to a remote DXL
  *   service.
- * @param {Function} [responseCallback=null] - An optional response callback
- *   that will be invoked when the corresponding {@link Response} message is
- *   received by the client.
+ * @param {Function} [responseCallback] - An optional response callback
+ *   that will be invoked with the result of the request.
+ *
+ *   If an error occurs during the request, the first parameter supplied to the
+ *   callback contains an {@link Error} with failure details. If the response
+ *   from the DXL fabric to the request includes an {@link ErrorResponse}, the
+ *   first parameter is a {@link RequestError} (which contains the error
+ *   response in its {@link RequestError#dxlErrorResponse} property).
+ *
+ *   If the request is successful, the second parameter includes a
+ *   {@link Response} message.
  * @throws {DxlError} If no prior attempt has been made to connect the client
  *   via a call to {@link Client#connect}.
  */

--- a/lib/dxl-error.js
+++ b/lib/dxl-error.js
@@ -6,6 +6,7 @@ var errorUtil = require('./error-util')
 /**
  * @classdesc A general Data Exchange Layer (DXL) exception.
  * @param {String} message - The error message.
+ * @augments Error
  * @constructor
  */
 function DxlError (message) {

--- a/lib/error-util.js
+++ b/lib/error-util.js
@@ -11,14 +11,21 @@ module.exports = {
    * on an {@link Error} function. This function is used to allow a function
    * to derive from the {@link Error} function.
    * @param {Object} obj - The object to initialize error data onto.
-   * @param {String} [message=null] - An error message.
+   * @param {String} [message] - An error message.
+   * @param {String} [code] - An error code.
    */
-  initializeError: function (obj, message) {
+  initializeError: function (obj, message, code) {
     Error.call(obj, message)
     if (Error.hasOwnProperty('captureStackTrace')) {
       Error.captureStackTrace(obj, obj.constructor)
     }
     obj.name = obj.constructor.name
+    if (code) {
+      obj.code = code
+      obj.name += ' [' + code + ']'
+    } else {
+      obj.code = ''
+    }
     obj.message = message
   }
 }

--- a/lib/malformed-broker-error.js
+++ b/lib/malformed-broker-error.js
@@ -7,6 +7,7 @@ var errorUtil = require('./error-util')
  * @classdesc An exception raised when a URL related to a DXL broker is
  *   malformed.
  * @param {String} message - The error message.
+ * @augments Error
  * @constructor
  */
 function MalformedBrokerError (message) {

--- a/lib/request-error.js
+++ b/lib/request-error.js
@@ -1,0 +1,64 @@
+'use strict'
+
+var inherits = require('inherits')
+var ResponseErrorCode = require('./response-error-code')
+var errorUtil = require('./error-util')
+
+var errorCodesToNames = {
+  0x80000001: ResponseErrorCode.SERVICE_UNAVAILABLE,
+  0x80000002: ResponseErrorCode.SERVICE_OVERLOADED,
+  0x80000003: ResponseErrorCode.RESPONSE_TIMEOUT
+}
+
+/**
+ * @classdesc An exception which can be passed in a response callback to
+ *   a failed {@link Client#asyncRequest} call.
+ * @param {ErrorResponse} errorResponse - The DXL {@link ErrorResponse}
+ *   returned from the DXL fabric for the failed request.
+ * @augments Error
+ * @constructor
+ */
+function RequestError (errorResponse) {
+  if (!errorResponse) {
+    throw new TypeError('Error did not include an errorResponse')
+  }
+
+  var errorMessage = errorResponse.errorMessage || errorResponse.payload
+
+  // Map a string for the error code if if the error is well-known.
+  var errorCodeString
+  if (errorResponse.hasOwnProperty('errorCode')) {
+    var normalizedErrorCode = errorResponse.errorCode
+    if (normalizedErrorCode < 0) {
+      normalizedErrorCode = 0xFFFFFFFF + normalizedErrorCode + 1
+    }
+    errorCodeString = errorCodesToNames[normalizedErrorCode]
+  }
+
+  /**
+   * String label that identifies the kind of error. See
+   * [ResponseErrorCode]{@link module:ResponseErrorCode}
+   * for a list of possible string constants.
+   * @name RequestError#code
+   * @type {String}
+   */
+
+  errorUtil.initializeError(this, errorMessage, errorCodeString)
+
+  /**
+   * The DXL {@link ErrorResponse} with more detail for the error.
+   * @type {ErrorResponse}
+   */
+  this.dxlErrorResponse = errorResponse
+
+  /**
+   * The DXL {@link ErrorResponse} with more detail for the error.
+   * @type {ErrorResponse}
+   * @deprecated in favor of {@link RequestError#dxlErrorResponse}
+   */
+  this.detail = this.dxlErrorResponse
+}
+
+inherits(RequestError, Error)
+
+module.exports = RequestError

--- a/lib/request-manager.js
+++ b/lib/request-manager.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var ErrorResponse = require('./error-response')
-var MessageError = require('./message-error')
+var RequestError = require('./request-error')
 
 /**
  * @classdesc Manager that tracks outstanding requests and notifies the
@@ -68,7 +68,7 @@ RequestManager.prototype.onResponse = function (response) {
   if (responseCallback) {
     delete this._requests[response.requestMessageId]
     if (response instanceof ErrorResponse) {
-      responseCallback(new MessageError(response), null)
+      responseCallback(new RequestError(response), null)
     } else {
       responseCallback(null, response)
     }

--- a/lib/response-error-code.js
+++ b/lib/response-error-code.js
@@ -1,0 +1,23 @@
+/**
+ * @module ResponseErrorCode
+ * @description Constants for error codes associated with a
+ * {@link RequestError#code}.
+ **/
+
+'use strict'
+
+module.exports = {
+  /**
+   * Error code returned by the broker when it is unable to locate a service
+   * for a request
+   */
+  SERVICE_UNAVAILABLE: 'ERR_DXL_SERVICE_UNAVAILABLE',
+  /**
+   * Error code returned by the broker when it is overloaded.
+   */
+  SERVICE_OVERLOADED: 'ERR_DXL_SERVICE_OVERLOADED',
+  /**
+   * Error code returned in a response when a request timed out.
+   */
+  RESPONSE_TIMEOUT: 'ERR_DXL_RESPONSE_TIMEOUT'
+}

--- a/lib/util.js
+++ b/lib/util.js
@@ -13,21 +13,6 @@ var DxlError = require('./dxl-error')
 
 module.exports = {
   /**
-   * Initialize the supplied object with the standard information which appears
-   * on an {@link Error} function. This function is used to allow a function
-   * to derive from the {@link Error} function.
-   * @param {Object} obj - The object to initialize error data onto.
-   * @param {String} [message=null] - An error message.
-   */
-  initializeError: function (obj, message) {
-    Error.call(obj, message)
-    if (Error.hasOwnProperty('captureStackTrace')) {
-      Error.captureStackTrace(obj, obj.constructor)
-    }
-    obj.name = obj.constructor.name
-    obj.message = message
-  },
-  /**
    * Generates and returns a random UUID that is all lowercase and has
    * enclosing brackets.
    * @returns {string}

--- a/sample/basic/service-example.js
+++ b/sample/basic/service-example.js
@@ -62,8 +62,17 @@ client.connect(function () {
             // Display the contents of an error, if one occurred
             if (error) {
               console.log('Request error: ' + error.message)
-              if (error instanceof dxl.MessageError) {
+              // The 'code' property, if set, typically has a string
+              // representation of the error code.
+              if (error.code) {
                 console.log('Request error code: ' + error.code)
+              // If no string representation is available for the error code
+              // but the error is a DXL 'RequestError', a numeric error
+              // code should be available in the
+              // 'dxlErrorResponse.errorCode' property.
+              } else if (error.dxlErrorResponse) {
+                console.log('Request error code: ' +
+                  error.dxlErrorResponse.errorCode)
               }
             // No error occurred, so extract information from the response. The
             // toString() call converts the payload from a binary Buffer into a

--- a/test/integration/broker-service-registry-test.js
+++ b/test/integration/broker-service-registry-test.js
@@ -5,9 +5,10 @@ var expect = require('chai').expect
 var dxl = require('../..')
 var ErrorResponse = dxl.ErrorResponse
 var Message = dxl.Message
-var MessageError = dxl.MessageError
 var Request = dxl.Request
 var Response = dxl.Response
+var ResponseErrorCode = dxl.ResponseErrorCode
+var RequestError = dxl.RequestError
 var ServiceRegistrationInfo = dxl.ServiceRegistrationInfo
 var util = require('../../lib/util')
 var TestClient = require('./test-client')
@@ -387,13 +388,12 @@ describe('broker service registry @integration', function () {
                             // topic it previously registered for the service.
                             expect(requestReceived).to.be.false
                             expect(response).to.be.null
-                            expect(error).to.be.an.instanceof(MessageError)
-                            expect(testHelpers.normalizedErrorCode(error)).to
-                              .equal(
-                                testHelpers.DXL_SERVICE_UNAVAILABLE_ERROR_CODE)
+                            expect(error).to.be.an.instanceof(RequestError)
+                            expect(error.code).to.equal(
+                              ResponseErrorCode.SERVICE_UNAVAILABLE)
                             expect(error.message).to.equal(
                               testHelpers.DXL_SERVICE_UNAVAILABLE_ERROR_MESSAGE)
-                            expect(error.detail).to.be.an.instanceof(
+                            expect(error.dxlErrorResponse).to.be.an.instanceof(
                               ErrorResponse)
                             // Validate that the service was initially
                             // registered with the broker.
@@ -463,13 +463,12 @@ describe('broker service registry @integration', function () {
                             // to an internally registered service.
                             expect(requestReceived).to.be.false
                             expect(response).to.be.null
-                            expect(error).to.be.an.instanceof(MessageError)
-                            expect(testHelpers.normalizedErrorCode(error)).to
-                              .equal(
-                                testHelpers.DXL_SERVICE_UNAVAILABLE_ERROR_CODE)
+                            expect(error).to.be.an.instanceof(RequestError)
+                            expect(error.code).to.equal(
+                              ResponseErrorCode.SERVICE_UNAVAILABLE)
                             expect(error.message).to.equal(
                               testHelpers.DXL_SERVICE_UNAVAILABLE_ERROR_MESSAGE)
-                            expect(error.detail).to.be.an.instanceof(
+                            expect(error.dxlErrorResponse).to.be.an.instanceof(
                               ErrorResponse)
                             // Validate that the service was initially
                             // registered with the broker.

--- a/test/integration/client-test.js
+++ b/test/integration/client-test.js
@@ -3,10 +3,11 @@
 
 var expect = require('chai').expect
 var dxl = require('../..')
-var MessageError = dxl.MessageError
 var ErrorResponse = dxl.ErrorResponse
 var Event = dxl.Event
 var Request = dxl.Request
+var RequestError = dxl.RequestError
+var ResponseErrorCode = dxl.ResponseErrorCode
 var ServiceRegistrationInfo = dxl.ServiceRegistrationInfo
 var util = require('../../lib/util')
 var TestClient = require('./test-client')
@@ -102,10 +103,10 @@ describe('Client @integration', function () {
         client.asyncRequest(new Request(topic), function (error, response) {
           client.shutdown(null, function () {
             expect(response).to.be.null
-            expect(error).to.be.an.instanceof(MessageError)
-            expect(error.code).to.equal(errorCode)
+            expect(error).to.be.an.instanceof(RequestError)
             expect(error.message).to.equal(errorMessage)
-            expect(error.detail).to.be.an.instanceof(ErrorResponse)
+            expect(error.dxlErrorResponse).to.be.an.instanceof(ErrorResponse)
+            expect(error.dxlErrorResponse.errorCode).to.equal(errorCode)
             done()
           })
         })
@@ -126,13 +127,12 @@ describe('Client @integration', function () {
       client.asyncRequest(request, function (error, response) {
         client.shutdown(null, function () {
           expect(response).to.be.null
-          expect(error).to.be.an.instanceof(MessageError)
-          expect(testHelpers.normalizedErrorCode(error)).to.equal(
-            testHelpers.DXL_SERVICE_UNAVAILABLE_ERROR_CODE)
+          expect(error).to.be.an.instanceof(RequestError)
+          expect(error.code).to.equal(ResponseErrorCode.SERVICE_UNAVAILABLE)
           expect(error.message).to.equal(
             testHelpers.DXL_SERVICE_UNAVAILABLE_ERROR_MESSAGE)
-          expect(error.detail).to.be.an.instanceof(ErrorResponse)
-          expect(error.detail.serviceId).to.equal(request.serviceId)
+          expect(error.dxlErrorResponse).to.be.an.instanceof(ErrorResponse)
+          expect(error.dxlErrorResponse.serviceId).to.equal(request.serviceId)
           done()
         })
       })

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -54,19 +54,5 @@ module.exports = {
     })
   },
   DXL_SERVICE_UNAVAILABLE_ERROR_CODE: 0x80000001,
-  DXL_SERVICE_UNAVAILABLE_ERROR_MESSAGE: 'unable to locate service for request',
-  /**
-   * Returns a normalized representation of the error code in a
-   * {@link MessageError}. A negative error code value would be converted to a
-   * 32-bit unsigned number.
-   * @param {MessageError} error - The error containing the code.
-   * @returns {Number} The error code (normalized as an unsigned 32-bit number).
-   */
-  normalizedErrorCode: function (error) {
-    var errorCode = 0
-    if ('code' in error) {
-      errorCode = error.code < 0 ? 0xFFFFFFFF + error.code + 1 : error.code
-    }
-    return errorCode
-  }
+  DXL_SERVICE_UNAVAILABLE_ERROR_MESSAGE: 'unable to locate service for request'
 }


### PR DESCRIPTION
This commit renames the MessageError class to RequestError in order
to tie it more directly to its use in the response to a client
asyncRequest().

Previously, the 'code' property for a MessageError contained the
errorCode value, a numeric type, from the DXL ErrorResponse. With
Node.js 8+, the 'code' property for derivatives of the Error class
(like MessageError) is expected to include a string-type value rather
than a numeric one. For compatibility with the newer Node.js versions,
this commit now populates a string-based value in the RequestError.code
property. The code property is only set to a non-empty string for
'well-defined' broker errors. For example, the value would be populated
with 'ERR_DXL_SERVICE_UNAVAILABLE' when the broker returns an
ErrorResponse for a request that cannot be routed.

An alias was created for the 'detail' property in the RequestError
class, 'dxlErrorResponse'. The 'dxl' prefixed property name allows for
consumers receiving a RequestError to more easily use duck typing to
derive the DXL-level error details - avoiding the need to use the
instanceof to distinguish a RequestError from other Error-type
classes. instanceof can be unreliable in cases where a RequestError
is being evaluated across packages which import separate instances
of the opendxl-client-javascript library from within the same Node.js
process.